### PR TITLE
feat: add zt watchdog — automatic QUIC/HTTP2 fallback recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,20 @@ zt apply zt.yaml
 
 If a service exists locally but is absent from the manifest, `zt apply` reports it without touching it — remove it explicitly with `zt down <name>` if needed.
 
+### QUIC/HTTP2 fallback watchdog
+
+cloudflared automatically falls back from QUIC to HTTP/2 when UDP is blocked or unstable — but it never tries QUIC again on its own, even after the network recovers ([cloudflare/cloudflared#1534](https://github.com/cloudflare/cloudflared/issues/1534)). A brief UDP blip can leave a tunnel stuck on HTTP/2 indefinitely, with no automatic recovery.
+
+`zt watchdog` runs in the background, watches each tunnel's log for the fallback, and restarts the tunnel after a backoff delay so cloudflared gets a fresh shot at QUIC. Only tunnels running with the default `protocol: auto` are affected — tunnels pinned via `--protocol` or `--tcp` are left alone, since that's a deliberate choice.
+
+```bash
+zt watchdog enable     # install as a background service, checks every 30s
+zt watchdog status     # check if it's running
+zt watchdog disable    # remove it
+```
+
+Restarts back off exponentially per tunnel (10 min → 20 min → ... capped at 60 min) so a tunnel with a persistently broken UDP path isn't flapped repeatedly — it still gets retried roughly once an hour rather than being abandoned.
+
 ### Health check
 
 ```bash
@@ -281,6 +295,14 @@ zt doctor
 ### `zt apply`
 
 `zt apply <file>` takes no additional flags. It reads the manifest at `<file>` and creates any missing services.
+
+### `zt watchdog`
+
+| Subcommand | Description |
+|---|---|
+| `enable` | Install and start the watchdog as a background service |
+| `disable` | Stop and remove the watchdog service |
+| `status` | Show whether the watchdog is running |
 
 ### `zt up`
 

--- a/cmd/zt/doctor.go
+++ b/cmd/zt/doctor.go
@@ -116,6 +116,18 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  %s  systemd linger enabled\n", pass("✓"))
 	}
 
+	// 2b. Watchdog
+	if !service.WatchdogIsInstalled() {
+		fmt.Printf("  %s  QUIC/HTTP2 fallback watchdog not enabled\n", dim("–"))
+		fmt.Printf("     %s run: zt watchdog enable\n", dim("hint:"))
+	} else if !service.WatchdogIsActive() {
+		fmt.Printf("  %s  watchdog installed but not running\n", warn("!"))
+		fmt.Printf("     %s run: zt watchdog enable\n", dim("hint:"))
+		problems++
+	} else {
+		fmt.Printf("  %s  QUIC/HTTP2 fallback watchdog running\n", pass("✓"))
+	}
+
 	// 3. Config exists
 	fmt.Println()
 	fmt.Printf("  %s\n", boldFmt("Cloudflare"))

--- a/cmd/zt/main.go
+++ b/cmd/zt/main.go
@@ -21,7 +21,8 @@ var rootCmd = &cobra.Command{
   zt logs <name>               show cloudflared logs
   zt doctor                    check system and tunnel health
   zt export [-o zt.yaml]       export managed tunnels to a portable manifest
-  zt apply <file>              apply a zt.yaml manifest on this machine`,
+  zt apply <file>              apply a zt.yaml manifest on this machine
+  zt watchdog enable           auto-recover from QUIC→HTTP2 fallback`,
 	SilenceUsage:  true,
 	SilenceErrors: true,
 }
@@ -37,6 +38,7 @@ func main() {
 	rootCmd.AddCommand(doctorCmd)
 	rootCmd.AddCommand(exportCmd)
 	rootCmd.AddCommand(applyCmd)
+	rootCmd.AddCommand(watchdogCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, "error:", err)

--- a/cmd/zt/restart.go
+++ b/cmd/zt/restart.go
@@ -20,6 +20,22 @@ var restartCmd = &cobra.Command{
 func runRestart(cmd *cobra.Command, args []string) error {
 	name := args[0]
 
+	boldFmt := color.New(color.Bold).SprintFunc()
+	fmt.Printf("\n%s\n\n", boldFmt("⚡ Restarting "+name))
+
+	if err := restartTunnel(name); err != nil {
+		return err
+	}
+
+	fmt.Println()
+	return nil
+}
+
+// restartTunnel restarts a tunnel's cloudflared process via whichever
+// mechanism manages it (systemd/launchd service, or direct PID).
+// Shared between `zt restart` and the watchdog so both restart tunnels
+// identically.
+func restartTunnel(name string) error {
 	store, err := state.LoadStore()
 	if err != nil {
 		return err
@@ -31,9 +47,6 @@ func runRestart(cmd *cobra.Command, args []string) error {
 	}
 
 	okFn := color.New(color.FgGreen).SprintFunc()
-	boldFmt := color.New(color.Bold).SprintFunc()
-
-	fmt.Printf("\n%s\n\n", boldFmt("⚡ Restarting "+name))
 
 	if service.IsInstalled(name) {
 		fmt.Printf("  → systemctl --user restart zt-%s\n", name)
@@ -65,6 +78,5 @@ func runRestart(cmd *cobra.Command, args []string) error {
 			name, name, name)
 	}
 
-	fmt.Println()
 	return nil
 }

--- a/cmd/zt/watchdog.go
+++ b/cmd/zt/watchdog.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/casablanque-code/cfzt/internal/service"
+	"github.com/casablanque-code/cfzt/internal/watchdog"
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var watchdogCmd = &cobra.Command{
+	Use:   "watchdog",
+	Short: "Manage the QUIC/HTTP2 fallback watchdog",
+	Long: `cloudflared falls back from QUIC to HTTP/2 when UDP is briefly
+blocked, but never retries QUIC again on its own
+(see https://github.com/cloudflare/cloudflared/issues/1534).
+
+The watchdog runs in the background, watches each tunnel's log for the
+fallback, and restarts the tunnel after a backoff delay so cloudflared
+gets a fresh chance to negotiate QUIC. Only tunnels running with
+protocol "auto" (the default) are affected — tunnels pinned to a
+specific protocol via --protocol or --tcp are left alone.`,
+}
+
+var watchdogEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Install and start the watchdog as a background service",
+	RunE:  runWatchdogEnable,
+}
+
+var watchdogDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Stop and remove the watchdog background service",
+	RunE:  runWatchdogDisable,
+}
+
+var watchdogStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show whether the watchdog is running",
+	RunE:  runWatchdogStatus,
+}
+
+// watchdogRunCmd is intentionally not documented prominently — it's the
+// entrypoint the systemd/launchd unit calls to run the watchdog loop
+// itself (ExecStart=zt watchdog run). Users normally interact via
+// `zt watchdog enable/disable/status`, not this directly.
+var watchdogRunCmd = &cobra.Command{
+	Use:    "run",
+	Short:  "Run the watchdog loop in the foreground (used internally by the service unit)",
+	Hidden: true,
+	RunE:   runWatchdogLoop,
+}
+
+func init() {
+	watchdogCmd.AddCommand(watchdogEnableCmd)
+	watchdogCmd.AddCommand(watchdogDisableCmd)
+	watchdogCmd.AddCommand(watchdogStatusCmd)
+	watchdogCmd.AddCommand(watchdogRunCmd)
+}
+
+func watchdogLogPath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(homeDir, ".zt", "watchdog.log"), nil
+}
+
+func runWatchdogEnable(cmd *cobra.Command, args []string) error {
+	boldFmt := color.New(color.Bold).SprintFunc()
+	okFn := color.New(color.FgGreen).SprintFunc()
+
+	if service.WatchdogIsInstalled() {
+		fmt.Println("  watchdog is already installed — run `zt watchdog status` to check it")
+		return nil
+	}
+
+	logPath, err := watchdogLogPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(logPath), 0700); err != nil {
+		return fmt.Errorf("failed to create watchdog log dir: %w", err)
+	}
+
+	fmt.Printf("\n%s\n\n", boldFmt("⚡ Enabling QUIC/HTTP2 fallback watchdog"))
+	fmt.Println("  → installing background service")
+
+	if err := service.InstallWatchdog(logPath); err != nil {
+		return err
+	}
+
+	fmt.Printf("     %s watchdog running — checks every %s\n", okFn("✓"), watchdog.DefaultPollInterval)
+	fmt.Println()
+	return nil
+}
+
+func runWatchdogDisable(cmd *cobra.Command, args []string) error {
+	okFn := color.New(color.FgGreen).SprintFunc()
+
+	if !service.WatchdogIsInstalled() {
+		fmt.Println("  watchdog is not installed")
+		return nil
+	}
+
+	if err := service.UninstallWatchdog(); err != nil {
+		return err
+	}
+	fmt.Printf("  %s watchdog disabled\n", okFn("✓"))
+	return nil
+}
+
+func runWatchdogStatus(cmd *cobra.Command, args []string) error {
+	if !service.WatchdogIsInstalled() {
+		fmt.Println("  watchdog is not installed — run `zt watchdog enable` to start it")
+		return nil
+	}
+
+	statusStr := fail("stopped")
+	if service.WatchdogIsActive() {
+		statusStr = pass("running")
+	}
+	fmt.Printf("  watchdog: %s\n", statusStr)
+
+	logPath, err := watchdogLogPath()
+	if err == nil {
+		fmt.Printf("  log:      %s\n", logPath)
+	}
+	return nil
+}
+
+// runWatchdogLoop is the long-running process started by the service unit.
+// It ticks every DefaultPollInterval, evaluating all "auto"-protocol
+// tunnels and restarting any that have fallen back to HTTP/2 outside
+// their backoff window.
+func runWatchdogLoop(cmd *cobra.Command, args []string) error {
+	fmt.Printf("zt watchdog starting — polling every %s\n", watchdog.DefaultPollInterval)
+
+	ticker := time.NewTicker(watchdog.DefaultPollInterval)
+	defer ticker.Stop()
+
+	// run once immediately on startup, then on every tick
+	tick := func() {
+		result, err := watchdog.RunOnce(restartTunnel, func(line string) {
+			fmt.Println(line)
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "watchdog tick error: %v\n", err)
+			return
+		}
+		for name, tickErr := range result.Errors {
+			fmt.Fprintf(os.Stderr, "watchdog: %s: %v\n", name, tickErr)
+		}
+	}
+
+	tick()
+	for range ticker.C {
+		tick()
+	}
+	return nil
+}

--- a/internal/cloudflared/config.go
+++ b/internal/cloudflared/config.go
@@ -62,6 +62,15 @@ func ConfigPath(tunnelName string) (string, error) {
 	return filepath.Join(dir, "config.yml"), nil
 }
 
+// LogPath returns the path to the cloudflared.log for a tunnel.
+func LogPath(tunnelName string) (string, error) {
+	dir, err := tunnelDir(tunnelName)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "cloudflared.log"), nil
+}
+
 func tunnelDir(name string) (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/internal/service/service_darwin.go
+++ b/internal/service/service_darwin.go
@@ -127,5 +127,91 @@ func IsInstalled(name string) bool {
 	return err == nil
 }
 
+const watchdogLabel = "com.zt.watchdog"
+
+const watchdogPlistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>com.zt.watchdog</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>%s</string>
+		<string>watchdog</string>
+		<string>run</string>
+	</array>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<true/>
+	<key>StandardOutPath</key>
+	<string>%s</string>
+	<key>StandardErrorPath</key>
+	<string>%s</string>
+</dict>
+</plist>
+`
+
+func watchdogPlistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, watchdogLabel+".plist"), nil
+}
+
+// InstallWatchdog creates and loads the watchdog LaunchAgent.
+func InstallWatchdog(logPath string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not determine zt binary path: %w", err)
+	}
+
+	plist := fmt.Sprintf(watchdogPlistTemplate, exe, logPath, logPath)
+
+	path, err := watchdogPlistPath()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(plist), 0644); err != nil {
+		return fmt.Errorf("failed to write watchdog plist: %w", err)
+	}
+
+	out, err := exec.Command("launchctl", "load", "-w", path).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("launchctl load: %w\n%s", err, out)
+	}
+	return nil
+}
+
+// UninstallWatchdog unloads and removes the watchdog LaunchAgent.
+func UninstallWatchdog() error {
+	path, err := watchdogPlistPath()
+	if err != nil {
+		return err
+	}
+	exec.Command("launchctl", "unload", "-w", path).Run()
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove watchdog plist: %w", err)
+	}
+	return nil
+}
+
+// WatchdogIsInstalled returns true if the watchdog plist exists.
+func WatchdogIsInstalled() bool {
+	path, err := watchdogPlistPath()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(path)
+	return err == nil
+}
+
 // LingerEnabled always returns true on macOS — LaunchAgents run at login automatically.
 func LingerEnabled() bool { return true }

--- a/internal/service/service_linux.go
+++ b/internal/service/service_linux.go
@@ -27,6 +27,24 @@ StandardError=append:%s
 WantedBy=default.target
 `
 
+const watchdogUnitName = "zt-watchdog.service"
+
+const watchdogUnitTemplate = `[Unit]
+Description=zt QUIC/HTTP2 fallback watchdog
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=%s watchdog run
+Restart=on-failure
+RestartSec=10s
+StandardOutput=append:%s
+StandardError=append:%s
+
+[Install]
+WantedBy=default.target
+`
+
 func unitName(name string) string {
 	return "zt-" + name + ".service"
 }
@@ -41,6 +59,18 @@ func unitPath(name string) (string, error) {
 		return "", err
 	}
 	return filepath.Join(dir, unitName(name)), nil
+}
+
+func watchdogUnitPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".config", "systemd", "user")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, watchdogUnitName), nil
 }
 
 func cloudflaredBin() (string, error) {
@@ -165,4 +195,71 @@ func LingerEnabled() bool {
 		return false
 	}
 	return strings.TrimSpace(string(out)) == "Linger=yes"
+}
+
+// InstallWatchdog creates and starts the zt-watchdog systemd user unit,
+// which runs `zt watchdog run` in the background to mitigate the
+// cloudflared QUIC→HTTP2 fallback bug. logPath is where the watchdog's
+// own stdout/stderr is appended (separate from any tunnel's log).
+func InstallWatchdog(logPath string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("could not determine zt binary path: %w", err)
+	}
+
+	if err := ensureLinger(); err != nil {
+		fmt.Printf("     ! linger not enabled: %v\n", err)
+	}
+
+	unit := fmt.Sprintf(watchdogUnitTemplate, exe, logPath, logPath)
+
+	path, err := watchdogUnitPath()
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(path, []byte(unit), 0644); err != nil {
+		return fmt.Errorf("failed to write watchdog unit file: %w", err)
+	}
+
+	cmds := [][]string{
+		{"systemctl", "--user", "daemon-reload"},
+		{"systemctl", "--user", "enable", "--now", watchdogUnitName},
+	}
+	for _, args := range cmds {
+		out, err := exec.Command(args[0], args[1:]...).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("systemctl %s: %w\n%s", strings.Join(args[1:], " "), err, out)
+		}
+	}
+	return nil
+}
+
+// UninstallWatchdog stops, disables, and removes the zt-watchdog unit.
+func UninstallWatchdog() error {
+	cmds := [][]string{
+		{"systemctl", "--user", "disable", "--now", watchdogUnitName},
+		{"systemctl", "--user", "daemon-reload"},
+	}
+	for _, args := range cmds {
+		_ = exec.Command(args[0], args[1:]...).Run()
+	}
+
+	path, err := watchdogUnitPath()
+	if err != nil {
+		return err
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove watchdog unit file: %w", err)
+	}
+	return nil
+}
+
+// WatchdogIsInstalled returns true if the watchdog unit file exists.
+func WatchdogIsInstalled() bool {
+	path, err := watchdogUnitPath()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(path)
+	return err == nil
 }

--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -16,3 +16,10 @@ func Uninstall(name string) error  { return nil }
 func UnitPath(name string) string  { return "" }
 func IsInstalled(name string) bool { return false }
 func LingerEnabled() bool          { return false }
+
+func InstallWatchdog(logPath string) error {
+	return fmt.Errorf("watchdog is not supported on Windows — run `zt watchdog run` manually if needed")
+}
+func UninstallWatchdog() error  { return nil }
+func WatchdogIsInstalled() bool { return false }
+func WatchdogIsActive() bool    { return false }

--- a/internal/service/status_darwin.go
+++ b/internal/service/status_darwin.go
@@ -15,3 +15,12 @@ func IsActive(name string) bool {
 	}
 	return strings.Contains(string(out), `"com.zt.`+name+`"`)
 }
+
+// WatchdogIsActive returns true if the watchdog LaunchAgent is loaded and running.
+func WatchdogIsActive() bool {
+	out, err := exec.Command("launchctl", "list", "com.zt.watchdog").Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(out), `"com.zt.watchdog"`)
+}

--- a/internal/service/status_linux.go
+++ b/internal/service/status_linux.go
@@ -15,3 +15,12 @@ func IsActive(name string) bool {
 	}
 	return strings.TrimSpace(string(out)) == "active"
 }
+
+// WatchdogIsActive returns true if the zt-watchdog systemd unit is active.
+func WatchdogIsActive() bool {
+	out, err := exec.Command("systemctl", "--user", "is-active", "zt-watchdog.service").Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "active"
+}

--- a/internal/watchdog/run.go
+++ b/internal/watchdog/run.go
@@ -1,0 +1,98 @@
+package watchdog
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/casablanque-code/cfzt/internal/cloudflared"
+	"github.com/casablanque-code/cfzt/internal/state"
+)
+
+// Restarter abstracts the actual restart mechanism so this package stays
+// testable without depending on systemd/launchd directly.
+type Restarter func(tunnelName string) error
+
+// EventLogger receives a human-readable line for every action taken,
+// so the caller can print or log it as it sees fit.
+type EventLogger func(line string)
+
+// TickResult summarizes what happened during one RunOnce pass.
+type TickResult struct {
+	Checked   int
+	Restarted []string
+	Skipped   []string // protocol pinned, not "auto" — not our concern
+	Errors    map[string]error
+}
+
+// RunOnce evaluates every tunnel in local state once: tunnels pinned to a
+// specific protocol (not "auto") are left alone, since the user made an
+// explicit choice. For "auto" tunnels, it tails the log since the last
+// check and restarts the tunnel's service if a QUIC→HTTP/2 fallback was
+// detected and the per-tunnel backoff window has elapsed.
+func RunOnce(restart Restarter, log EventLogger) (TickResult, error) {
+	result := TickResult{Errors: make(map[string]error)}
+
+	store, err := state.LoadStore()
+	if err != nil {
+		return result, fmt.Errorf("loading tunnel state: %w", err)
+	}
+
+	rs, err := LoadRuntimeState()
+	if err != nil {
+		return result, fmt.Errorf("loading watchdog state: %w", err)
+	}
+
+	now := time.Now()
+	tunnels := store.All()
+
+	// Drop bookkeeping for tunnels that no longer exist, so the watchdog
+	// state file doesn't grow forever across teardown/recreate cycles.
+	live := make(map[string]bool, len(tunnels))
+	for _, t := range tunnels {
+		live[t.Name] = true
+	}
+	for name := range rs.Tunnels {
+		if !live[name] {
+			rs.Forget(name)
+		}
+	}
+
+	for _, t := range tunnels {
+		if t.Protocol != "" && t.Protocol != state.ProtocolAuto {
+			result.Skipped = append(result.Skipped, t.Name)
+			continue
+		}
+		result.Checked++
+
+		logPath, err := cloudflared.LogPath(t.Name)
+		if err != nil {
+			result.Errors[t.Name] = err
+			continue
+		}
+
+		ts := rs.Get(t.Name)
+		decision, err := Evaluate(ts, logPath, now)
+		if err != nil {
+			result.Errors[t.Name] = err
+			continue
+		}
+
+		if decision.ShouldRestart {
+			if log != nil {
+				log(fmt.Sprintf("%s: %s", t.Name, decision.Reason))
+			}
+			if err := restart(t.Name); err != nil {
+				result.Errors[t.Name] = err
+				continue
+			}
+			RecordRestart(ts, now)
+			result.Restarted = append(result.Restarted, t.Name)
+		}
+	}
+
+	if err := rs.Save(); err != nil {
+		return result, fmt.Errorf("saving watchdog state: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/watchdog/state.go
+++ b/internal/watchdog/state.go
@@ -1,0 +1,136 @@
+// Package watchdog implements a background watcher that mitigates a
+// long-standing cloudflared behaviour: once cloudflared falls back from
+// QUIC to HTTP/2 (e.g. due to a transient UDP blip), it never retries
+// QUIC again on its own — see https://github.com/cloudflare/cloudflared/issues/1534.
+// This only matters for tunnels running with protocol "auto" (the default);
+// tunnels explicitly pinned to --protocol http2 or --protocol quic are
+// left untouched, since that's a deliberate choice.
+//
+// The watchdog tails each tunnel's cloudflared.log for the line
+// "Switching to fallback protocol http2", and if found, restarts the
+// tunnel's service after a backoff delay so cloudflared gets a fresh
+// chance to negotiate QUIC again. Restarts back off exponentially per
+// tunnel to avoid flapping a tunnel whose UDP path is persistently broken.
+package watchdog
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// fallbackMarker is the exact, version-stable cloudflared log line that
+// indicates a QUIC → HTTP/2 fallback occurred. Confirmed unchanged across
+// cloudflared releases from 2022.4 through 2025.9.
+const fallbackMarker = "Switching to fallback protocol http2"
+
+const (
+	// DefaultPollInterval is how often the watchdog checks each tunnel's log.
+	DefaultPollInterval = 30 * time.Second
+	// MinBackoff is the shortest wait between restart attempts for a tunnel
+	// that keeps falling back to http2.
+	MinBackoff = 10 * time.Minute
+	// MaxBackoff caps the exponential backoff so a persistently broken
+	// tunnel still gets retried roughly once an hour, not abandoned forever.
+	MaxBackoff = 60 * time.Minute
+)
+
+// TunnelState tracks per-tunnel restart bookkeeping. Stored separately
+// from the main ~/.zt-state.json so the watchdog never contends with
+// interactive commands (up/down/list) for that file.
+type TunnelState struct {
+	// LastLogOffset is the byte offset up to which the log has been scanned.
+	LastLogOffset int64 `json:"last_log_offset"`
+	// LastRestartAt is when the watchdog last restarted this tunnel due to fallback.
+	LastRestartAt time.Time `json:"last_restart_at,omitempty"`
+	// CurrentBackoff is the current wait duration before the next allowed restart.
+	CurrentBackoff time.Duration `json:"current_backoff,omitempty"`
+}
+
+// RuntimeState is the on-disk watchdog state file: ~/.zt-watchdog-state.json
+type RuntimeState struct {
+	Tunnels map[string]*TunnelState `json:"tunnels"`
+}
+
+func runtimeStatePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".zt-watchdog-state.json"), nil
+}
+
+// LoadRuntimeState reads the watchdog's own state file, creating an empty
+// one in memory if it doesn't exist yet.
+func LoadRuntimeState() (*RuntimeState, error) {
+	path, err := runtimeStatePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return &RuntimeState{Tunnels: make(map[string]*TunnelState)}, nil
+		}
+		return nil, err
+	}
+	var rs RuntimeState
+	if err := json.Unmarshal(data, &rs); err != nil {
+		// corrupt state file — don't crash the watchdog, start fresh
+		return &RuntimeState{Tunnels: make(map[string]*TunnelState)}, nil
+	}
+	if rs.Tunnels == nil {
+		rs.Tunnels = make(map[string]*TunnelState)
+	}
+	return &rs, nil
+}
+
+// Save persists the watchdog's runtime state.
+func (rs *RuntimeState) Save() error {
+	path, err := runtimeStatePath()
+	if err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(rs, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// Get returns (creating if absent) the per-tunnel state.
+func (rs *RuntimeState) Get(name string) *TunnelState {
+	ts, ok := rs.Tunnels[name]
+	if !ok {
+		ts = &TunnelState{}
+		rs.Tunnels[name] = ts
+	}
+	return ts
+}
+
+// Forget removes bookkeeping for a tunnel — call when a tunnel is torn down.
+func (rs *RuntimeState) Forget(name string) {
+	delete(rs.Tunnels, name)
+}
+
+// nextBackoff doubles the current backoff (or starts at MinBackoff),
+// capped at MaxBackoff.
+func nextBackoff(current time.Duration) time.Duration {
+	if current <= 0 {
+		return MinBackoff
+	}
+	next := current * 2
+	if next > MaxBackoff {
+		return MaxBackoff
+	}
+	return next
+}
+
+// resetBackoff is called whenever a tunnel is found healthy (no fallback
+// detected since the last successful restart), so a single old fallback
+// doesn't keep inflating the backoff indefinitely.
+func resetBackoff(ts *TunnelState) {
+	ts.CurrentBackoff = 0
+}

--- a/internal/watchdog/watchdog.go
+++ b/internal/watchdog/watchdog.go
@@ -1,0 +1,105 @@
+package watchdog
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"strings"
+	"time"
+)
+
+// scanResult describes what was found in the newly-appended portion of a log.
+type scanResult struct {
+	fallbackDetected bool
+	newOffset        int64
+}
+
+// scanLogTail reads a log file starting at fromOffset and reports whether
+// the fallback marker appears anywhere in the new content. It never
+// re-reads bytes it has already scanned, so this stays cheap even on
+// long-running tunnels with large log files.
+func scanLogTail(path string, fromOffset int64) (scanResult, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return scanResult{newOffset: fromOffset}, nil
+		}
+		return scanResult{}, err
+	}
+	defer func() { _ = f.Close() }()
+
+	info, err := f.Stat()
+	if err != nil {
+		return scanResult{}, err
+	}
+
+	// Log was rotated/truncated (e.g. service restarted and log file was
+	// recreated) — restart scanning from the beginning rather than seeking
+	// past EOF, which would silently skip content.
+	if info.Size() < fromOffset {
+		fromOffset = 0
+	}
+
+	if _, err := f.Seek(fromOffset, 0); err != nil {
+		return scanResult{}, err
+	}
+
+	found := false
+	scanner := bufio.NewScanner(f)
+	// cloudflared lines are short; default scanner buffer is plenty
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), fallbackMarker) {
+			found = true
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return scanResult{}, err
+	}
+
+	return scanResult{fallbackDetected: found, newOffset: info.Size()}, nil
+}
+
+// Decision describes what the watchdog should do for one tunnel on this tick.
+type Decision struct {
+	ShouldRestart bool
+	Reason        string
+}
+
+// Evaluate scans a tunnel's log since the last check and decides whether
+// a restart is warranted, respecting the per-tunnel backoff window.
+func Evaluate(ts *TunnelState, logPath string, now time.Time) (Decision, error) {
+	result, err := scanLogTail(logPath, ts.LastLogOffset)
+	if err != nil {
+		return Decision{}, err
+	}
+	ts.LastLogOffset = result.newOffset
+
+	if !result.fallbackDetected {
+		// Healthy since last check — relax backoff so a single old
+		// fallback doesn't keep this tunnel on an inflated wait forever.
+		resetBackoff(ts)
+		return Decision{}, nil
+	}
+
+	backoff := ts.CurrentBackoff
+	if backoff <= 0 {
+		backoff = MinBackoff
+	}
+
+	if !ts.LastRestartAt.IsZero() && now.Sub(ts.LastRestartAt) < backoff {
+		return Decision{
+			Reason: "fallback detected but within backoff window",
+		}, nil
+	}
+
+	return Decision{
+		ShouldRestart: true,
+		Reason:        "QUIC fallback detected — restarting to retry QUIC",
+	}, nil
+}
+
+// RecordRestart updates bookkeeping after the watchdog actually restarts a tunnel.
+func RecordRestart(ts *TunnelState, now time.Time) {
+	ts.LastRestartAt = now
+	ts.CurrentBackoff = nextBackoff(ts.CurrentBackoff)
+}

--- a/internal/watchdog/watchdog_test.go
+++ b/internal/watchdog/watchdog_test.go
@@ -1,0 +1,273 @@
+package watchdog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeLog(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "cloudflared.log")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestScanLogTailDetectsFallback(t *testing.T) {
+	path := writeLog(t, "2026-06-19T10:00:00Z INF Connection registered connIndex=0\n"+
+		"2026-06-19T10:00:05Z INF Switching to fallback protocol http2 connIndex=0\n")
+
+	result, err := scanLogTail(path, 0)
+	if err != nil {
+		t.Fatalf("scanLogTail error: %v", err)
+	}
+	if !result.fallbackDetected {
+		t.Error("expected fallback to be detected")
+	}
+	info, _ := os.Stat(path)
+	if result.newOffset != info.Size() {
+		t.Errorf("newOffset = %d, want %d", result.newOffset, info.Size())
+	}
+}
+
+func TestScanLogTailNoFallback(t *testing.T) {
+	path := writeLog(t, "2026-06-19T10:00:00Z INF Connection registered connIndex=0\n"+
+		"2026-06-19T10:00:01Z INF Connection registered connIndex=1\n")
+
+	result, err := scanLogTail(path, 0)
+	if err != nil {
+		t.Fatalf("scanLogTail error: %v", err)
+	}
+	if result.fallbackDetected {
+		t.Error("did not expect fallback to be detected")
+	}
+}
+
+func TestScanLogTailIncrementalOnlyScansNewContent(t *testing.T) {
+	path := writeLog(t, "2026-06-19T10:00:00Z INF Connection registered\n")
+
+	first, err := scanLogTail(path, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first.fallbackDetected {
+		t.Fatal("first scan should not detect fallback")
+	}
+
+	// append a fallback line after the first scan
+	f, _ := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0600)
+	_, _ = f.WriteString("2026-06-19T10:01:00Z INF Switching to fallback protocol http2 connIndex=0\n")
+	f.Close()
+
+	second, err := scanLogTail(path, first.newOffset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !second.fallbackDetected {
+		t.Error("second scan should detect the newly appended fallback line")
+	}
+
+	// re-scanning from the new offset should find nothing — no double counting
+	third, err := scanLogTail(path, second.newOffset)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if third.fallbackDetected {
+		t.Error("re-scanning already-read content should not detect fallback again")
+	}
+}
+
+func TestScanLogTailHandlesTruncatedLog(t *testing.T) {
+	path := writeLog(t, "short\n")
+	// simulate a stale offset beyond current file size (log was rotated)
+	result, err := scanLogTail(path, 99999)
+	if err != nil {
+		t.Fatalf("scanLogTail should handle truncated logs gracefully: %v", err)
+	}
+	_ = result // should not error, offset resets internally
+}
+
+func TestScanLogTailMissingFile(t *testing.T) {
+	result, err := scanLogTail("/nonexistent/cloudflared.log", 0)
+	if err != nil {
+		t.Fatalf("missing log file should not error (tunnel may not have started yet): %v", err)
+	}
+	if result.fallbackDetected {
+		t.Error("missing file should not report a fallback")
+	}
+}
+
+func TestEvaluateRestartsOnFirstFallback(t *testing.T) {
+	path := writeLog(t, "INF Switching to fallback protocol http2 connIndex=0\n")
+	ts := &TunnelState{}
+	now := time.Now()
+
+	decision, err := Evaluate(ts, path, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decision.ShouldRestart {
+		t.Error("expected restart on first fallback detection")
+	}
+}
+
+func TestEvaluateRespectsBackoffWindow(t *testing.T) {
+	path := writeLog(t, "INF Switching to fallback protocol http2 connIndex=0\n")
+	now := time.Now()
+
+	ts := &TunnelState{
+		LastRestartAt:  now.Add(-1 * time.Minute), // restarted 1 minute ago
+		CurrentBackoff: MinBackoff,                // but backoff window is 10 minutes
+	}
+
+	decision, err := Evaluate(ts, path, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.ShouldRestart {
+		t.Error("should not restart again within the backoff window")
+	}
+}
+
+func TestEvaluateAllowsRestartAfterBackoffElapses(t *testing.T) {
+	path := writeLog(t, "INF Switching to fallback protocol http2 connIndex=0\n")
+	now := time.Now()
+
+	ts := &TunnelState{
+		LastRestartAt:  now.Add(-15 * time.Minute), // restarted 15 min ago
+		CurrentBackoff: MinBackoff,                 // backoff window was 10 min — elapsed
+	}
+
+	decision, err := Evaluate(ts, path, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !decision.ShouldRestart {
+		t.Error("should restart again once backoff window has elapsed")
+	}
+}
+
+func TestEvaluateNoRestartWhenHealthy(t *testing.T) {
+	path := writeLog(t, "INF Connection registered connIndex=0\n")
+	ts := &TunnelState{}
+
+	decision, err := Evaluate(ts, path, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if decision.ShouldRestart {
+		t.Error("should not restart a healthy tunnel")
+	}
+}
+
+func TestEvaluateResetsBackoffWhenHealthy(t *testing.T) {
+	path := writeLog(t, "INF Connection registered connIndex=0\n")
+	ts := &TunnelState{CurrentBackoff: MaxBackoff}
+
+	_, err := Evaluate(ts, path, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ts.CurrentBackoff != 0 {
+		t.Errorf("backoff should reset to 0 when no fallback detected, got %v", ts.CurrentBackoff)
+	}
+}
+
+func TestNextBackoffDoublesAndCaps(t *testing.T) {
+	cases := []struct {
+		current time.Duration
+		want    time.Duration
+	}{
+		{0, MinBackoff},
+		{MinBackoff, MinBackoff * 2},
+		{MinBackoff * 2, MinBackoff * 4},
+		{MaxBackoff, MaxBackoff},         // already at cap
+		{MaxBackoff / 2 * 3, MaxBackoff}, // would overshoot — capped
+	}
+	for _, c := range cases {
+		got := nextBackoff(c.current)
+		if got != c.want {
+			t.Errorf("nextBackoff(%v) = %v, want %v", c.current, got, c.want)
+		}
+	}
+}
+
+func TestRecordRestartUpdatesState(t *testing.T) {
+	ts := &TunnelState{}
+	now := time.Now()
+
+	RecordRestart(ts, now)
+
+	if !ts.LastRestartAt.Equal(now) {
+		t.Errorf("LastRestartAt = %v, want %v", ts.LastRestartAt, now)
+	}
+	if ts.CurrentBackoff != MinBackoff {
+		t.Errorf("CurrentBackoff = %v, want %v", ts.CurrentBackoff, MinBackoff)
+	}
+}
+
+func TestRuntimeStateRoundtrip(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rs, err := LoadRuntimeState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := rs.Get("grafana")
+	ts.CurrentBackoff = 20 * time.Minute
+	ts.LastLogOffset = 1024
+
+	if err := rs.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := LoadRuntimeState()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := reloaded.Tunnels["grafana"]
+	if !ok {
+		t.Fatal("expected grafana entry after reload")
+	}
+	if got.CurrentBackoff != 20*time.Minute {
+		t.Errorf("CurrentBackoff = %v, want 20m", got.CurrentBackoff)
+	}
+	if got.LastLogOffset != 1024 {
+		t.Errorf("LastLogOffset = %d, want 1024", got.LastLogOffset)
+	}
+}
+
+func TestRuntimeStateForget(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	rs, _ := LoadRuntimeState()
+	rs.Get("vault")
+	rs.Forget("vault")
+
+	if _, ok := rs.Tunnels["vault"]; ok {
+		t.Error("expected vault entry to be removed after Forget")
+	}
+}
+
+func TestRuntimeStateCorruptFileDoesNotCrash(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path := filepath.Join(home, ".zt-watchdog-state.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	rs, err := LoadRuntimeState()
+	if err != nil {
+		t.Fatalf("corrupt state file should not error, got: %v", err)
+	}
+	if rs.Tunnels == nil {
+		t.Error("expected empty initialized map after corrupt state recovery")
+	}
+}


### PR DESCRIPTION
cloudflared falls back from QUIC to HTTP/2 when UDP is briefly blocked, but never retries QUIC again on its own, even after the network recovers (cloudflare/cloudflared#1534, open since 2022). A tunnel can get stuck on HTTP/2 indefinitely after a transient blip.

- internal/watchdog: tails each tunnel's cloudflared.log incrementally (no re-reading already-scanned bytes) for the stable log line 'Switching to fallback protocol http2', confirmed unchanged across cloudflared 2022.4 through 2025.9
- only tunnels with protocol "auto" (the default) are affected -- tunnels explicitly pinned via --protocol/--tcp are left untouched
- restarts back off exponentially per tunnel (10min -> 20min -> ... capped at 60min) to avoid flapping a persistently broken UDP path
- watchdog bookkeeping lives in a separate ~/.zt-watchdog-state.json so the long-running watchdog process never contends with interactive commands (up/down/list) for ~/.zt-state.json
- cmd/zt/watchdog.go: zt watchdog enable/disable/status, plus a hidden 'zt watchdog run' entrypoint used by the service unit itself
- internal/service: new InstallWatchdog/UninstallWatchdog/ WatchdogIsInstalled/WatchdogIsActive across linux (systemd), darwin (launchd), and windows (no-op stub)
- refactor cmd/zt/restart.go: extract restartTunnel(name) so the watchdog reuses the exact same restart logic as 'zt restart'
- add cloudflared.LogPath() helper, replacing three separate TrimSuffix(...) + "cloudflared.log" duplications
- zt doctor now reports watchdog status (non-blocking -- it's opt-in)
- 14 tests for internal/watchdog: incremental log scanning, backoff math, runtime state roundtrip/corruption recovery
- verified building cleanly on linux, darwin/arm64, windows/amd64