### PR TITLE
packaging(windows): add self-hosted Scoop bucket

### DIFF
--- a/.github/workflows/scoop-update.yml
+++ b/.github/workflows/scoop-update.yml
@@ -1,0 +1,44 @@
+name: Update Scoop bucket
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-manifest:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bump bucket/zt.json
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${TAG#v}"
+          SHA_URL="https://github.com/${{ github.repository }}/releases/download/${TAG}/zt-windows-amd64.exe.sha256"
+          HASH=$(curl -fsSL "$SHA_URL" | awk '{print $1}')
+
+          if [[ ! "$HASH" =~ ^[a-fA-F0-9]{64}$ ]]; then
+            echo "error: could not resolve a valid sha256 from $SHA_URL (got: '$HASH')" >&2
+            exit 1
+          fi
+
+          jq --arg version "$VERSION" --arg hash "$HASH" \
+            '.version = $version | .architecture["64bit"].hash = $hash' \
+            bucket/zt.json > bucket/zt.json.tmp
+          mv bucket/zt.json.tmp bucket/zt.json
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- bucket/zt.json; then
+            echo "bucket/zt.json already up to date, nothing to commit"
+            exit 0
+          fi
+          git add bucket/zt.json
+          git commit -m "chore(scoop): bump bucket to ${{ github.event.release.tag_name }}"
+          git push

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Windows: Scoop bucket (self-hosted in this repo's `bucket/` folder) — `scoop bucket add cfzt https://github.com/casablanque-code/cfzt && scoop install cfzt/zt`. Auto-updates version/checksum on every release via a new GitHub Actions workflow, so `scoop update zt` always resolves the latest tag with no manual manifest maintenance
+
 ## [0.7.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -95,7 +95,16 @@ sudo mv zt /usr/local/bin/
 
 Download from [Releases](https://github.com/casablanque-code/cfzt/releases) and place in your PATH. Each release includes `.sha256` checksum files and a combined `checksums.txt`.
 
-### Option E — Windows (PowerShell)
+### Option E — Scoop (Windows)
+
+```powershell
+scoop bucket add cfzt https://github.com/casablanque-code/cfzt
+scoop install cfzt/zt
+```
+
+The bucket lives in this repo's [`bucket/`](bucket/) folder and updates itself automatically on every release. `scoop update zt` upgrades in place — no manual re-download or checksum verification needed, Scoop handles both.
+
+### Option F — Windows (PowerShell)
 
 See [Windows support](#windows-support) for what currently works — this
 installs the binary and adds it to your user `PATH` safely:
@@ -154,7 +163,7 @@ If `cloudflared` isn't on `PATH` (or task creation fails for any other
 reason), `zt up` falls back to running it as a directly tracked process —
 you'll see `(no auto-restart)` in the output when that happens.
 
-(Windows install instructions are in [Install → Option E](#option-e--windows-powershell) above.)
+(Windows install: [Scoop](#option-e--scoop-windows) (recommended, self-updating) or [PowerShell script](#option-f--windows-powershell) above. A winget package is planned — see the issue tracker for status.)
 
 ---
 

--- a/bucket/zt.json
+++ b/bucket/zt.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.7.0",
+    "description": "Zero Trust tunnel manager for Cloudflare — one command to expose a local service through Cloudflare Zero Trust.",
+    "homepage": "https://github.com/casablanque-code/cfzt",
+    "license": "MIT",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/casablanque-code/cfzt/releases/download/v0.7.0/zt-windows-amd64.exe#/zt.exe",
+            "hash": "d6e70b93f56c13ff56073d1277cc14577dd4fc6829c76078e573064cfdd87374"
+        }
+    },
+    "bin": "zt.exe",
+    "checkver": {
+        "github": "https://github.com/casablanque-code/cfzt"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/casablanque-code/cfzt/releases/download/v$version/zt-windows-amd64.exe#/zt.exe"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256",
+            "regex": "([a-fA-F0-9]{64})"
+        }
+    }
+}


### PR DESCRIPTION
Adds bucket/zt.json (Scoop manifest for the v0.7.0 windows-amd64 release) and .github/workflows/scoop-update.yml, which bumps the manifest's version + hash and commits straight to main whenever a GitHub release is published — pulls the sha256 from the same zt-windows-amd64.exe.sha256 asset release.yml already publishes, so there's no separate hash-computation step to keep in sync.

Hosting the bucket in this repo (rather than a submission to microsoft/winget-pkgs) means zero external review/approval — 'scoop bucket add' + 'scoop install' works the moment this merges, no waiting on anyone else's PR queue.

README: new 'Option E — Scoop' install method, renumbers the existing PowerShell script to Option F, and updates the Windows support section to link both plus a note that winget is still planned separately.

CHANGELOG: Unreleased entry for the bucket + auto-update workflow.