### PR TITLE
fix(service/windows): XML-escape task XML values — fixes real 'malfor…

### DIFF
--- a/internal/service/service_windows.go
+++ b/internal/service/service_windows.go
@@ -4,6 +4,7 @@ package service
 
 import (
 	"encoding/binary"
+	"encoding/xml"
 	"fmt"
 	"os"
 	"os/exec"
@@ -66,18 +67,39 @@ const watchdogTaskName = "zt-watchdog"
 // buildTaskXML renders a Task Scheduler task definition for running cmd
 // with args at user logon, restarting on failure. description is used for
 // the task's RegistrationInfo only — purely informational.
+//
+// description/cmd/args are XML-escaped before insertion. Without this,
+// any value containing an XML special character produces a task file
+// Windows rejects outright — the log-redirection wrapper's "2>&1", for
+// instance, has a bare '&' that made every Install()/InstallWatchdog()
+// call fail with "ERROR: The task XML is malformed."
 func buildTaskXML(description, cmd string, args ...string) string {
 	quoted := make([]string, len(args))
 	for i, a := range args {
 		quoted[i] = quoteArg(a)
 	}
-	return fmt.Sprintf(taskXMLTemplate, description, cmd, strings.Join(quoted, " "))
+	return fmt.Sprintf(taskXMLTemplate,
+		xmlEscapeText(description),
+		xmlEscapeText(cmd),
+		xmlEscapeText(strings.Join(quoted, " ")),
+	)
+}
+
+// xmlEscapeText escapes s for use as XML element text content.
+func xmlEscapeText(s string) string {
+	var buf strings.Builder
+	// xml.EscapeText never returns an error for a strings.Builder target.
+	_ = xml.EscapeText(&buf, []byte(s))
+	return buf.String()
 }
 
 // quoteArg wraps an argument in double quotes for the Task Scheduler
 // <Arguments> string, escaping any embedded double quotes. Paths on
 // Windows routinely contain spaces (Program Files, user profile dirs),
-// so unquoted arguments would be split incorrectly.
+// so unquoted arguments would be split incorrectly. This is cmd.exe/CRT
+// argument-quoting syntax, applied before the XML escaping in
+// buildTaskXML — the two operate on different layers and both are
+// needed.
 func quoteArg(a string) string {
 	return `"` + strings.ReplaceAll(a, `"`, `\"`) + `"`
 }

--- a/internal/service/service_windows_test.go
+++ b/internal/service/service_windows_test.go
@@ -3,6 +3,8 @@
 package service
 
 import (
+	"encoding/xml"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,25 +47,56 @@ func TestQuoteArg(t *testing.T) {
 }
 
 func TestBuildTaskXML(t *testing.T) {
-	xml := buildTaskXML("zt tunnel — grafana", "cmd.exe", "/c", `"C:\cloudflared.exe" tunnel run`)
+	taskXML := buildTaskXML("zt tunnel — grafana", "cmd.exe", "/c", `"C:\cloudflared.exe" tunnel run`)
 
 	for _, want := range []string{
 		"<Description>zt tunnel — grafana</Description>",
 		"<Command>cmd.exe</Command>",
-		`<Arguments>"/c" "\"C:\cloudflared.exe\" tunnel run"</Arguments>`,
+		// quoteArg's cmd.exe-quoting happens first, then xmlEscapeText
+		// escapes the resulting double quotes for XML text content.
+		`<Arguments>&#34;/c&#34; &#34;\&#34;C:\cloudflared.exe\&#34; tunnel run&#34;</Arguments>`,
 		"<LogonTrigger>",
 		"<RestartOnFailure>",
 	} {
-		if !strings.Contains(xml, want) {
-			t.Errorf("buildTaskXML() missing %q in output:\n%s", want, xml)
+		if !strings.Contains(taskXML, want) {
+			t.Errorf("buildTaskXML() missing %q in output:\n%s", want, taskXML)
 		}
 	}
 
 	// The XML must never request stored credentials - that's what keeps
 	// Install() from needing admin rights or a password prompt.
 	for _, unwanted := range []string{"<LogonType>Password</LogonType>", "<UserId>"} {
-		if strings.Contains(xml, unwanted) {
+		if strings.Contains(taskXML, unwanted) {
 			t.Errorf("buildTaskXML() contains %q, task should not require stored credentials", unwanted)
+		}
+	}
+}
+
+// TestBuildTaskXML_EscapesAmpersand is a regression test for the exact
+// output Install()/InstallWatchdog() generate for their cmd.exe log
+// redirection wrapper (">> log 2>&1"). The unescaped '&' produced XML
+// schtasks rejected with "ERROR: The task XML is malformed.", failing
+// every real zt up / zt watchdog enable on Windows.
+func TestBuildTaskXML_EscapesAmpersand(t *testing.T) {
+	inner := `"C:\cloudflared.exe" tunnel run >> "C:\cloudflared.log" 2>&1`
+	got := buildTaskXML("zt tunnel — grafana", "cmd.exe", "/c", inner)
+
+	if strings.Contains(got, "2>&1") {
+		t.Errorf("buildTaskXML() contains a raw unescaped '&', want it escaped as &amp;:\n%s", got)
+	}
+	if !strings.Contains(got, "2&gt;&amp;1") {
+		t.Errorf("buildTaskXML() = %s, want the redirect escaped as 2&gt;&amp;1", got)
+	}
+
+	dec := xml.NewDecoder(strings.NewReader(strings.Replace(got, `encoding="UTF-16"`, `encoding="UTF-8"`, 1)))
+	for {
+		_, err := dec.Token()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Errorf("buildTaskXML() output does not parse as XML: %v\n%s", err, got)
+			break
 		}
 	}
 }


### PR DESCRIPTION
…med XML' failure

Install() and InstallWatchdog() build a cmd.exe wrapper for log redirection whose inner command always contains '>> logpath 2>&1'. That bare '&' was inserted into <Arguments> via fmt.Sprintf with zero XML escaping, producing a task file schtasks rejected outright:

  ERROR: The task XML is malformed.
  (30,193):Arguments:

This made every real 'zt up' and 'zt watchdog enable' on Windows fail to install a service and silently fall back to PID mode — the exact failure reported from live testing. quoteArg's cmd.exe-quoting and this XML-escaping operate on different layers (shell argument syntax vs. XML text content) and both are needed; quoteArg still runs first, then xmlEscapeText escapes the result.

Adds TestBuildTaskXML_EscapesAmpersand, which reproduces the exact '2>&1' input that broke in production and additionally verifies the output round-trips through an XML decoder. Updates the existing Arguments assertion in TestBuildTaskXML for the now-escaped quotes.