### PR TITLE
fix(ci): Scoop bucket bump forgot to update the url field

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,7 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           HASH=$(awk '{print $1}' dist/zt-windows-amd64.exe.sha256)
+          URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}/zt-windows-amd64.exe#/zt.exe"
 
           if [[ ! "$HASH" =~ ^[a-fA-F0-9]{64}$ ]]; then
             echo "error: could not read a valid sha256 from dist/zt-windows-amd64.exe.sha256 (got: '$HASH')" >&2
@@ -71,8 +72,13 @@ jobs:
           git fetch origin main
           git checkout -B main origin/main
 
-          jq --arg version "$VERSION" --arg hash "$HASH" \
-            '.version = $version | .architecture["64bit"].hash = $hash' \
+          # Every field the manifest pins to a specific release —
+          # version, url, hash — must be bumped together. Missing the
+          # url here once already shipped a bucket that reported the
+          # new version but downloaded the previous release's binary
+          # and failed its own hash check.
+          jq --arg version "$VERSION" --arg url "$URL" --arg hash "$HASH" \
+            '.version = $version | .architecture["64bit"].url = $url | .architecture["64bit"].hash = $hash' \
             bucket/zt.json > bucket/zt.json.tmp
           mv bucket/zt.json.tmp bucket/zt.json
 

--- a/bucket/zt.json
+++ b/bucket/zt.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "architecture": {
     "64bit": {
-      "url": "https://github.com/casablanque-code/cfzt/releases/download/v0.7.1/zt-windows-amd64.exe#/zt.exe",
+      "url": "https://github.com/casablanque-code/cfzt/releases/download/v0.7.2/zt-windows-amd64.exe#/zt.exe",
       "hash": "8fe1efe0ab42a1599c03d3479cb24d01d98b8798622439aa92ba50b6cf610ddb"
     }
   },


### PR DESCRIPTION
release.yml's jq filter bumped .version and .architecture["64bit"].hash on every release but never touched .architecture["64bit"].url — it stayed pinned to whatever URL was last set by hand (v0.7.1, from the earlier manual bucket fix). The v0.7.2 release bumped version and hash correctly but left url pointing at the v0.7.1 asset, so 'scoop update zt' downloaded the old v0.7.1 binary and hash-checked it against the new v0.7.2 hash:

  Expected: 8fe1efe0...  (real v0.7.2 hash)
  Actual:   78ce3640...  (v0.7.1's hash — the binary it actually got)

Every field the manifest pins to a release needs to move together. Manually re-points bucket/zt.json's url at the real v0.7.2 asset right now (this doesn't need a new release, the v0.7.2 binary is already published) and fixes the jq filter to set url alongside version/hash going forward.