### PR TITLE
feat: add cfzt-action — composite GitHub Action for PR preview tunnels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `casablanque-code/cfzt` is now also a composite GitHub Action wrapping `zt up`/`zt down` for PR preview environments, with a GitHub Deployment + Deployment Status reflecting the tunnel in the PR's own UI. State is bridged across the separate `up`/`down` workflow runs via `actions/cache`, keyed by tunnel name — see the new "GitHub Action" section in the README for usage and its limitations
+
 ## [0.8.3] - 2026-08-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -66,10 +66,81 @@ zt down pr-142
 ```
 
 Self-hosted preview URLs without Vercel, Netlify, or a hosted preview
-platform. A GitHub Action that wires this into PR checks and the
-deployments UI automatically is planned — see the issue tracker.
+platform. `casablanque-code/cfzt` ships a composite action wrapping the
+`zt up`/`zt down` calls above and reflecting them in the GitHub
+Deployments UI — see [GitHub Action](#github-action) below.
 
 ---
+
+## GitHub Action
+
+`casablanque-code/cfzt` is also a composite action wrapping `zt up`/`zt
+down` for exactly the PR-preview flow above, plus a GitHub Deployment +
+Deployment Status so the preview URL shows up in the PR's own UI, not just
+build logs.
+
+```yaml
+name: PR preview
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  deployments: write   # needed for the GitHub Deployments UI integration
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        if: github.event.action != 'closed'
+      # ... build your image / start the container on localhost:3000 ...
+
+      - uses: casablanque-code/cfzt@v0.8.3
+        if: github.event.action != 'closed'
+        with:
+          mode: up
+          name: pr-${{ github.event.number }}
+          port: '3000'
+          docker: 'true'
+          public: 'true'   # or use `allow:` to restrict to your team
+          domain: example.com
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - uses: casablanque-code/cfzt@v0.8.3
+        if: github.event.action == 'closed'
+        with:
+          mode: down
+          name: pr-${{ github.event.number }}
+          domain: example.com
+          cloudflare-api-token: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          cloudflare-account-id: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+Notes:
+
+- **`name` must match** between the `up` and `down` calls — it's the
+  tunnel name, the hostname prefix, and the cache key the action uses to
+  find the tunnel again on `down` (see below).
+- **State across runs:** `up` and `down` normally run in entirely
+  separate, unrelated jobs — possibly weeks apart — so there's no
+  filesystem to share between them the way there would be within a single
+  job. The action bridges that with `actions/cache`, saving `~/.zt-state.json`
+  and `~/.zt` after `up` and restoring them before `down`. If that cache
+  entry has been evicted (GitHub's normal cache eviction, or the 7-day
+  unused-entry limit) by the time `down` runs, `zt down` will fail with
+  "tunnel not found in local state" and the Cloudflare Tunnel/DNS
+  record/Access app will need cleaning up by hand (`zt down` run locally
+  against restored state, or via the Cloudflare dashboard) until cfzt
+  itself gains a way to resolve and destroy a tunnel by name straight from
+  the Cloudflare API, without local state — see the issue tracker.
+- `permissions: deployments: write` is required on the calling workflow
+  for the Deployments UI integration — a composite action can't grant
+  itself permissions. Set `create-deployment: 'false'` to skip that part
+  entirely and just get the tunnel.
+
+See [`action.yml`](action.yml) for the full list of inputs.
 
 ## What it does
 

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,274 @@
+name: 'cfzt preview tunnel'
+description: >-
+  Bring up or tear down a Cloudflare Zero Trust tunnel with cfzt (zt), and
+  reflect it in the GitHub Deployments UI. Built for PR preview environments:
+  "up" on PR open/sync, "down" on PR close.
+author: casablanque-code
+branding:
+  icon: cloud-lightning
+  color: orange
+
+inputs:
+  mode:
+    description: "'up' to create the tunnel, 'down' to tear it down."
+    required: true
+  name:
+    description: >-
+      Tunnel name. Also becomes the hostname (<name>.<domain>) and the
+      cache/deployment key — use the *same* name on the "up" and "down"
+      call for a given preview (e.g. "pr-${{ github.event.number }}").
+    required: true
+  domain:
+    description: 'Cloudflare zone the tunnel hostname is created under.'
+    required: true
+  cloudflare-api-token:
+    description: >-
+      Cloudflare API token with Account/Cloudflare Tunnel/Edit,
+      Zone/DNS/Edit, and Account/Access: Apps and Policies/Edit.
+    required: true
+  cloudflare-account-id:
+    description: 'Cloudflare account ID.'
+    required: true
+  port:
+    description: 'Local port to expose. Required for mode=up unless docker is true.'
+    required: false
+    default: ''
+  docker:
+    description: 'Auto-detect the port from a Docker container named `name`. mode=up only.'
+    required: false
+    default: 'false'
+  public:
+    description: >-
+      No Zero Trust Access login — anyone with the URL can view it.
+      Mutually exclusive with allow. mode=up only.
+    required: false
+    default: 'false'
+  allow:
+    description: >-
+      Newline-separated emails to restrict access to via Cloudflare Access.
+      Mutually exclusive with public. mode=up only.
+    required: false
+    default: ''
+  tcp:
+    description: 'Force TCP/http2 instead of QUIC. mode=up only.'
+    required: false
+    default: 'false'
+  protocol:
+    description: 'cloudflared protocol: auto, quic, or http2. mode=up only.'
+    required: false
+    default: 'auto'
+  force:
+    description: >-
+      Replace a pre-existing DNS record for the hostname that a previous
+      cfzt run didn't create. mode=up only.
+    required: false
+    default: 'false'
+  environment:
+    description: 'GitHub Deployments environment name. Defaults to `name`.'
+    required: false
+    default: ''
+  create-deployment:
+    description: 'Record this up/down in the GitHub Deployments UI.'
+    required: false
+    default: 'true'
+  github-token:
+    description: 'Token used for the Deployments API. Needs the `deployments: write` permission.'
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  url:
+    description: 'https:// URL of the tunnel. Set for mode=up.'
+    value: ${{ steps.hostname.outputs.url }}
+  hostname:
+    description: 'Bare hostname of the tunnel, e.g. pr-142.example.com.'
+    value: ${{ steps.hostname.outputs.hostname }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate inputs
+      shell: bash
+      env:
+        MODE: ${{ inputs.mode }}
+        DOCKER: ${{ inputs.docker }}
+        PORT: ${{ inputs.port }}
+      run: |
+        set -euo pipefail
+        case "$MODE" in
+          up|down) ;;
+          *) echo "::error::mode must be 'up' or 'down', got '$MODE'"; exit 1 ;;
+        esac
+        if [ "$MODE" = "up" ] && [ "$DOCKER" != "true" ] && [ -z "$PORT" ]; then
+          echo "::error::port is required for mode=up unless docker is true"
+          exit 1
+        fi
+
+    - name: Compute hostname
+      id: hostname
+      shell: bash
+      env:
+        NAME: ${{ inputs.name }}
+        DOMAIN: ${{ inputs.domain }}
+        MODE: ${{ inputs.mode }}
+      run: |
+        set -euo pipefail
+        hostname="${NAME}.${DOMAIN}"
+        echo "hostname=${hostname}" >> "$GITHUB_OUTPUT"
+        if [ "$MODE" = "up" ]; then
+          echo "url=https://${hostname}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Resolve deployment environment name
+      id: env-name
+      shell: bash
+      env:
+        ENVIRONMENT: ${{ inputs.environment }}
+        NAME: ${{ inputs.name }}
+      run: |
+        set -euo pipefail
+        echo "environment=${ENVIRONMENT:-$NAME}" >> "$GITHUB_OUTPUT"
+
+    - name: Install cloudflared
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v cloudflared >/dev/null 2>&1; then
+          echo "cloudflared already on PATH: $(cloudflared --version)"
+          exit 0
+        fi
+        arch="$(uname -m)"
+        case "$arch" in
+          x86_64) asset=cloudflared-linux-amd64 ;;
+          aarch64|arm64) asset=cloudflared-linux-arm64 ;;
+          *) echo "::error::unsupported architecture for cloudflared: $arch"; exit 1 ;;
+        esac
+        curl -fsSL "https://github.com/cloudflare/cloudflared/releases/latest/download/${asset}" -o /usr/local/bin/cloudflared
+        chmod +x /usr/local/bin/cloudflared
+        cloudflared --version
+
+    - name: Install cfzt
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v zt >/dev/null 2>&1; then
+          echo "zt already on PATH: $(zt version)"
+          exit 0
+        fi
+        curl -fsSL https://raw.githubusercontent.com/casablanque-code/cfzt/main/install.sh | bash
+
+    - name: Write cfzt config
+      shell: bash
+      env:
+        CF_API_TOKEN: ${{ inputs.cloudflare-api-token }}
+        CF_ACCOUNT_ID: ${{ inputs.cloudflare-account-id }}
+        DOMAIN: ${{ inputs.domain }}
+      run: |
+        set -euo pipefail
+        jq -n \
+          --arg api_token "$CF_API_TOKEN" \
+          --arg account_id "$CF_ACCOUNT_ID" \
+          --arg domain "$DOMAIN" \
+          '{api_token: $api_token, account_id: $account_id, domain: $domain}' \
+          > "${HOME}/.zt-config.json"
+        chmod 600 "${HOME}/.zt-config.json"
+
+    - name: Restore tunnel state
+      if: inputs.mode == 'down'
+      uses: actions/cache/restore@v4
+      with:
+        path: |
+          ~/.zt-state.json
+          ~/.zt
+        key: cfzt-preview-${{ inputs.name }}
+
+    - name: zt up
+      if: inputs.mode == 'up'
+      shell: bash
+      env:
+        NAME: ${{ inputs.name }}
+        PORT: ${{ inputs.port }}
+        DOCKER: ${{ inputs.docker }}
+        PUBLIC: ${{ inputs.public }}
+        ALLOW: ${{ inputs.allow }}
+        TCP: ${{ inputs.tcp }}
+        PROTOCOL: ${{ inputs.protocol }}
+        FORCE: ${{ inputs.force }}
+      run: |
+        set -euo pipefail
+        args=(up "$NAME")
+        if [ "$DOCKER" = "true" ]; then
+          args+=(--docker)
+          [ -n "$PORT" ] && args+=("$PORT")
+        else
+          args+=("$PORT")
+        fi
+        [ "$PUBLIC" = "true" ] && args+=(--public)
+        while IFS= read -r email; do
+          [ -n "$email" ] && args+=(--allow "$email")
+        done <<< "$ALLOW"
+        [ "$TCP" = "true" ] && args+=(--tcp)
+        [ -n "$PROTOCOL" ] && [ "$PROTOCOL" != "auto" ] && args+=(--protocol "$PROTOCOL")
+        [ "$FORCE" = "true" ] && args+=(--force)
+        zt "${args[@]}"
+
+    - name: Save tunnel state
+      if: inputs.mode == 'up'
+      uses: actions/cache/save@v4
+      with:
+        path: |
+          ~/.zt-state.json
+          ~/.zt
+        key: cfzt-preview-${{ inputs.name }}
+
+    - name: Record GitHub deployment
+      if: inputs.mode == 'up' && inputs.create-deployment == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        REF: ${{ github.sha }}
+        ENVIRONMENT: ${{ steps.env-name.outputs.environment }}
+        URL: ${{ steps.hostname.outputs.url }}
+      run: |
+        set -euo pipefail
+        # required_contexts: [] matters here — without it the Deployments
+        # API defers to the repo's required status checks and can refuse
+        # to create the deployment before they've all passed, which isn't
+        # what we want for a preview tunnel that IS one of the checks.
+        payload=$(jq -n \
+          --arg ref "$REF" \
+          --arg environment "$ENVIRONMENT" \
+          --arg description "cfzt preview: $URL" \
+          '{ref: $ref, environment: $environment, description: $description, auto_merge: false, required_contexts: []}')
+        deployment_id=$(gh api "repos/${REPO}/deployments" --method POST --input - <<< "$payload" --jq '.id')
+
+        status_payload=$(jq -n \
+          --arg environment "$ENVIRONMENT" \
+          --arg environment_url "$URL" \
+          '{state: "success", environment: $environment, environment_url: $environment_url, description: "tunnel live"}')
+        gh api "repos/${REPO}/deployments/${deployment_id}/statuses" --method POST --input - <<< "$status_payload"
+
+    - name: zt down
+      if: inputs.mode == 'down'
+      shell: bash
+      env:
+        NAME: ${{ inputs.name }}
+      run: zt down "$NAME"
+
+    - name: Mark GitHub deployment inactive
+      if: inputs.mode == 'down' && inputs.create-deployment == 'true'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        ENVIRONMENT: ${{ steps.env-name.outputs.environment }}
+      run: |
+        set -euo pipefail
+        ids=$(gh api "repos/${REPO}/deployments?environment=${ENVIRONMENT}" --jq '.[].id')
+        for id in $ids; do
+          gh api "repos/${REPO}/deployments/${id}/statuses" \
+            --method POST \
+            -f "state=inactive" \
+            -f "environment=${ENVIRONMENT}"
+        done


### PR DESCRIPTION
Wraps `zt up`/`zt down` for the PR-preview workflow already documented in the README, and reflects each tunnel in the GitHub Deployments UI (a real Deployment + Deployment Status, environment_url set to the tunnel's URL) instead of leaving it buried in build logs.

Notable design points:

- Every input is passed into `run:` steps via `env:` and referenced as `$VAR`, never interpolated directly into script text via `${{ }}` - the standard mitigation for the well-known GitHub Actions script- injection class of bug (untrusted `inputs.*`/`github.*` values landing in a shell string verbatim).
- JSON payloads (cfzt's own config file, the two Deployments API bodies) are built with `jq -n --arg ...` rather than string interpolation or a nested heredoc script, for the same reason plus proper escaping - a heredoc-based approach was tried first and dropped for a subtler bug: heredoc body indentation is passed through to the interpreter verbatim, which broke Python's own parsing of the intended top-level statements.
- State problem worth calling out: `zt down` requires the tunnel in cfzt's own local state file, but "up" (PR opened) and "down" (PR closed) are separate workflow runs on unrelated ephemeral runners with no shared filesystem. Bridged with actions/cache/save+restore keyed by tunnel name - "up" snapshots ~/.zt-state.json and ~/.zt after a successful run, "down" restores them first. Documented the failure mode (cache eviction) and the real fix for it (cfzt gaining a way to resolve/destroy a tunnel from the Cloudflare API alone, no local state - a candidate for a future round, not this one).
- required_contexts: [] on deployment creation is deliberate, not default behavior - without it the Deployments API defers to the repo's required status checks, which can refuse to create the deployment before they've all passed. Not what we want when the preview tunnel IS one of the checks.

Verified: action.yml parses as valid YAML (PyYAML) and every embedded `run:` block round-trips through `bash -n` cleanly. Nothing here can be exercised end-to-end without a real Cloudflare account/token - that part needs a live test on your side, ideally in a scratch repo before pointing a real project's PR workflow at it.

README gets a "GitHub Action" section (replacing the old "planned - see the issue tracker" line) with a full example workflow and the state-bridging caveat above spelled out for users, not just this commit message.